### PR TITLE
lttng: add int type definitions

### DIFF
--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -1,5 +1,6 @@
 #include "tracing/tracing-common.h"
 #include "include/rados/librados.h"
+#include "include/int_types.h"
 
 TRACEPOINT_EVENT(librados, rados_create_enter,
     TP_ARGS(

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1,5 +1,6 @@
 #include "tracing/tracing-common.h"
 #include "include/rbd/librbd.h"
+#include "include/int_types.h"
 
 TRACEPOINT_EVENT(librbd, read_enter,
     TP_ARGS(

--- a/src/tracing/objectstore.tp
+++ b/src/tracing/objectstore.tp
@@ -1,3 +1,5 @@
+#include "include/int_types.h"
+
 TRACEPOINT_EVENT(objectstore, exists_enter,
     TP_ARGS(
         const char *, coll_name),

--- a/src/tracing/oprequest.tp
+++ b/src/tracing/oprequest.tp
@@ -1,3 +1,5 @@
+#include "include/int_types.h"
+
 TRACEPOINT_EVENT(oprequest, set_rmw_flags,
     TP_ARGS(
         // osd_reqid_t

--- a/src/tracing/osd.tp
+++ b/src/tracing/osd.tp
@@ -1,3 +1,5 @@
+#include "include/int_types.h"
+
 TRACEPOINT_EVENT(osd, prepare_tx_enter,
     TP_ARGS(
         // osd_reqid_t

--- a/src/tracing/pg.tp
+++ b/src/tracing/pg.tp
@@ -1,3 +1,5 @@
+#include "include/int_types.h"
+
 TRACEPOINT_EVENT(pg, queue_op,
     TP_ARGS(
         // osd_reqid_t


### PR DESCRIPTION
The normal path through #include <lttng/tracepoint.h> doesn't
appear to include int defintions like uint64_t that are used
in Ceph so we add our definitions file.

Signed-off-by: Noah Watkins noahwatkins@gmail.com
